### PR TITLE
bugfix:修复调度器未完全保存进程上下文的问题；以及switch proc的汇编代码的undefined behaviour的问题

### DIFF
--- a/kernel/src/process/process.c
+++ b/kernel/src/process/process.c
@@ -513,7 +513,7 @@ ul initial_kernel_thread(ul arg)
     // kdebug("current_pcb->thread->rsp=%#018lx", current_pcb->thread->rsp);
     current_pcb->flags = 0;
     // 将返回用户层的代码压入堆栈，向rdx传入regs的地址，然后jmp到do_execve这个系统调用api的处理函数
-    // 这里的设计思路和switch_proc类似 加载用户态程序：shell.elf
+    // 这里的设计思路和switch_to类似 加载用户态程序：shell.elf
     __asm__ __volatile__("movq %1, %%rsp   \n\t"
                          "pushq %2    \n\t"
                          "jmp do_execve  \n\t" ::"D"(current_pcb->thread->rsp),

--- a/kernel/src/process/process.h
+++ b/kernel/src/process/process.h
@@ -51,23 +51,23 @@ extern uint64_t process_exit_files(struct process_control_block *pcb);
  * 然后调用__switch_to切换栈，配置其他信息，最后恢复下一个进程的rax rbp。
  */
 
-#define switch_proc(prev, next)                                                                                        \
+#define switch_to(prev, next)                                                                                          \
     do                                                                                                                 \
     {                                                                                                                  \
         __asm__ __volatile__("pushq	%%rbp	\n\t"                                                                        \
                              "pushq	%%rax	\n\t"                                                                        \
                              "movq	%%rsp,	%0	\n\t"                                                                     \
                              "movq	%2,	%%rsp	\n\t"                                                                     \
-                             "leaq	switch_proc_ret_addr(%%rip),	%%rax	\n\t"                                            \
+                             "leaq	2f(%%rip),	%%rax	\n\t"                                                              \
                              "movq	%%rax,	%1	\n\t"                                                                     \
                              "pushq	%3		\n\t"                                                                          \
                              "jmp	__switch_to	\n\t"                                                                    \
-                             "switch_proc_ret_addr:	\n\t"                                                              \
+                             "2:	\n\t"                                                                                 \
                              "popq	%%rax	\n\t"                                                                         \
                              "popq	%%rbp	\n\t"                                                                         \
                              : "=m"(prev->thread->rsp), "=m"(prev->thread->rip)                                        \
                              : "m"(next->thread->rsp), "m"(next->thread->rip), "D"(prev), "S"(next)                    \
-                             : "memory");                                                                              \
+                             : "memory", "rax");                                                                       \
     } while (0)
 
 /**

--- a/kernel/src/sched/sched.h
+++ b/kernel/src/sched/sched.h
@@ -77,3 +77,4 @@ void sched_init();
  */
 void sched_update_jiffies();
 
+void switch_proc(struct process_control_block *prev, struct process_control_block *proc);

--- a/kernel/src/syscall/syscall.c
+++ b/kernel/src/syscall/syscall.c
@@ -23,6 +23,7 @@ extern uint64_t sys_kill(struct pt_regs *regs);
 extern uint64_t sys_sigaction(struct pt_regs * regs);
 extern uint64_t sys_rt_sigreturn(struct pt_regs * regs);
 extern uint64_t sys_getpid(struct pt_regs * regs);
+extern uint64_t sys_sched(struct pt_regs * regs);
 
 /**
  * @brief 导出系统调用处理函数的符号
@@ -592,6 +593,7 @@ system_call_t system_call_table[MAX_SYSTEM_CALL_NUM] = {
     [24] = sys_sigaction,
     [25] = sys_rt_sigreturn,
     [26] = sys_getpid,
-    [27 ... 254] = system_call_not_exists,
+    [27] = sys_sched,
+    [28 ... 254] = system_call_not_exists,
     [255] = sys_ahci_end_req,
 };

--- a/kernel/src/syscall/syscall_num.h
+++ b/kernel/src/syscall/syscall_num.h
@@ -37,6 +37,7 @@
 #define SYS_KILL 23         // kill一个进程(向这个进程发出信号)
 #define SYS_SIGACTION 24    // 设置进程的信号处理动作
 #define SYS_RT_SIGRETURN 25 // 从信号处理函数返回
-#define SYS_GETPID 26 // 获取当前进程的pid（进程标识符）
+#define SYS_GETPID 26       // 获取当前进程的pid（进程标识符）
+#define SYS_SCHED 27        // 让系统立即运行调度器（该系统调用不能由运行在Ring3的程序发起）
 
 #define SYS_AHCI_END_REQ 255 // AHCI DMA请求结束end_request的系统调用


### PR DESCRIPTION
bugfix:修复当使用sched()运行调度器，在切换进程的时候，由于不在中断上下文内，导致当前进程的上下文丢失的问题。
bugfix:修复切换进程的宏的汇编代码的损坏部分，未声明`rax`寄存器，从而导致的编译器未定义行为问题。